### PR TITLE
Realign mobile navigation header

### DIFF
--- a/src/components/shared/Header2/NewHeader.tsx
+++ b/src/components/shared/Header2/NewHeader.tsx
@@ -1,5 +1,5 @@
 import { PixelSize, Row } from "lib/chakraUtils";
-import { Icon, useDisclosure } from "@chakra-ui/react";
+import { Flex, Icon, useDisclosure } from "@chakra-ui/react";
 
 //  Components
 import DashboardBox, { DASHBOARD_BOX_SPACING } from "../DashboardBox";
@@ -44,7 +44,7 @@ export const NewHeader = () => {
         px={4}
         height="38px"
         my={4}
-        mainAxisAlignment="space-around"
+        mainAxisAlignment="space-between"
         crossAxisAlignment="center"
         overflowX="visible"
         overflowY="visible"
@@ -68,7 +68,6 @@ export const NewHeader = () => {
             // transform="translate(0px, 7px)"
             height="100%"
           >
-
             {/* Dropdown  */}
             <DropDownLink
               name={t("Products")}
@@ -91,21 +90,23 @@ export const NewHeader = () => {
         )}
 
         {!isMobile && <HeaderSearchbar />}
-        <AccountButton />
-        {isMobile && (
-          <DashboardBox
-            ml={1}
-            as="button"
-            height="40px"
-            flexShrink={0}
-            width="50px"
-            fontSize="15px"
-            onClick={openNavModal}
-            fontWeight="bold"
-          >
-            <Icon as={HamburgerIcon} />
-          </DashboardBox>
-        )}
+        <Flex>
+          <AccountButton />
+          {isMobile && (
+            <DashboardBox
+              ml={3}
+              as="button"
+              height="40px"
+              flexShrink={0}
+              width="50px"
+              fontSize="15px"
+              onClick={openNavModal}
+              fontWeight="bold"
+            >
+              <Icon as={HamburgerIcon} />
+            </DashboardBox>
+          )}
+        </Flex>
       </Row>
 
       <MobileNavModal


### PR DESCRIPTION
Pretty quick fix (just some flexbox stuff). I also visually verified that these code changes do not change the desktop view.

## Old Alignment

<img width="416" alt="Screen Shot 2022-01-16 at 16 02 38" src="https://user-images.githubusercontent.com/10874225/149683529-aeb350a1-3381-4ea4-a831-5fb52a659db0.png">

## New Alignment

<img width="417" alt="Screen Shot 2022-01-16 at 16 01 41" src="https://user-images.githubusercontent.com/10874225/149683508-0a949996-6eb3-42e1-ac04-92d235558d91.png">

