### PR TITLE
Clean up mobile navigation modal

### DIFF
--- a/src/components/shared/Header2/HeaderSearchbar.tsx
+++ b/src/components/shared/Header2/HeaderSearchbar.tsx
@@ -1,10 +1,11 @@
 import { Box } from "@chakra-ui/react";
+import React from "react";
 import Searchbar from "../Searchbar";
 
-const HeaderSearchbar = (props: any) => {
+const HeaderSearchbar: React.FC<React.ComponentProps<typeof Box>> = (props) => {
   return (
-    <Box  w={800} mx={5} my="auto " alignSelf="flex-start" {...props}>
-      <Searchbar  height="33px" smaller/>
+    <Box w={800} mx={5} my="auto " alignSelf="flex-start" {...props}>
+      <Searchbar height="33px" smaller />
     </Box>
   );
 };

--- a/src/components/shared/Header2/MobileNavModal.tsx
+++ b/src/components/shared/Header2/MobileNavModal.tsx
@@ -1,4 +1,3 @@
-import { InfoIcon } from "@chakra-ui/icons";
 import {
   Modal,
   ModalOverlay,
@@ -9,23 +8,78 @@ import {
   AccordionPanel,
   AccordionIcon,
   Box,
-  Text,
   Heading,
+  Flex,
 } from "@chakra-ui/react";
 
-import { Column, Row } from "lib/chakraUtils";
+import { Column } from "lib/chakraUtils";
 
 import { useTranslation } from "next-i18next";
 
 import { useRari } from "context/RariContext";
+import {
+  GOVERNANCE_DROPDOWN_ITEMS,
+  PRODUCTS_DROPDOWN_ITEMS,
+  UTILS_DROPDOWN_ITEMS,
+} from "constants/nav";
 
-import { GlowingButton } from "../GlowingButton";
-import { AnimatedSmallLogo } from "../Logos";
-import { ModalDivider, ModalTitleWithCloseButton, MODAL_PROPS } from "../Modal";
-
-import { SimpleTooltip } from "../SimpleTooltip";
-import HeaderSearchbar from "./HeaderSearchbar";
 import AppLink from "../AppLink";
+import { ModalDivider, ModalTitleWithCloseButton, MODAL_PROPS } from "../Modal";
+import HeaderSearchbar from "./HeaderSearchbar";
+import { MenuItemInterface, MenuItemType } from "./HeaderLink";
+
+interface MobileNavAccordionItemProps {
+  name: string;
+  items: MenuItemInterface[];
+}
+
+const MobileNavAccordionItem: React.FC<MobileNavAccordionItemProps> = ({
+  name,
+  items,
+}) => {
+  return (
+    <AccordionItem py={3} h="100%" w="100%" flex={1} border="none">
+      <AccordionButton>
+        <Box flex="1" textAlign="left">
+          <Heading size="md">{name}</Heading>
+        </Box>
+        <AccordionIcon />
+      </AccordionButton>
+      <AccordionPanel pb={4}>
+        <Flex flexDirection="column">
+          {items.map((item) => {
+            if (item.type === MenuItemType.LINK) {
+              return (
+                <Box py={1}>
+                  <AppLink href={item.link?.route} key={item.link?.route}>
+                    {item.link?.name}
+                  </AppLink>
+                </Box>
+              );
+            } else if (item.type === MenuItemType.MENUGROUP) {
+              return (
+                <Box mt={4}>
+                  <Heading size="sm" fontWeight="normal" color="grey" mb={2}>
+                    {item.title}
+                  </Heading>
+                  {item.links?.map((link) => (
+                    <Box py={1}>
+                      <AppLink href={link.route} key={link.route}>
+                        {link.name}
+                      </AppLink>
+                    </Box>
+                  )) ?? null}
+                </Box>
+              );
+            } else {
+              return null;
+            }
+          })}
+        </Flex>
+      </AccordionPanel>
+    </AccordionItem>
+  );
+};
 
 export const MobileNavModal = ({
   isOpen,
@@ -38,8 +92,6 @@ export const MobileNavModal = ({
 }) => {
   const { t } = useTranslation();
 
-  const { address, rari } = useRari();
-
   return (
     <Modal
       motionPreset="slideInBottom"
@@ -49,7 +101,7 @@ export const MobileNavModal = ({
     >
       <ModalOverlay />
       <ModalContent {...MODAL_PROPS}>
-        <ModalTitleWithCloseButton text={t("Nav")} onClose={onClose} />
+        <ModalTitleWithCloseButton text="Rari" onClose={onClose} />
 
         <ModalDivider />
 
@@ -59,134 +111,24 @@ export const MobileNavModal = ({
           crossAxisAlignment="center"
           p={4}
         >
-          <AppLink
-            href="/fuse"
-            as={Box}
-            h="100%"
-            w="100%"
-            flex="1"
-            _hover={{ background: "grey" }}
-            p={3}
-            onClick={onClose}
-          >
-            <Heading size="md">Fuse</Heading>
-          </AppLink>
-
           <Accordion allowToggle w="100%">
-            {/* Vaults */}
-            <AccordionItem p={3} h="100%" w="100%" flex="1">
-              <AccordionButton>
-                <Box flex="1" textAlign="left">
-                  <Heading size="md">Vaults</Heading>
-                </Box>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel pb={4}>
-                <AppLink
-                  href="/pools/usdc"
-                  as={Box}
-                  h="100%"
-                  w="100%"
-                  flex="1"
-                  _hover={{ background: "grey" }}
-                  p={3}
-                  onClick={onClose}
-                >
-                  <Heading size="sm">USDC</Heading>
-                </AppLink>
-                <ModalDivider />
-                <AppLink
-                  href="/pools/dai"
-                  as={Box}
-                  h="100%"
-                  w="100%"
-                  flex="1"
-                  _hover={{ background: "grey" }}
-                  p={3}
-                  onClick={onClose}
-                >
-                  <Heading size="sm">DAI</Heading>
-                </AppLink>
-              </AccordionPanel>
-            </AccordionItem>
-
-            {/* Gov */}
-            <AccordionItem p={3} h="100%" w="100%" flex="1">
-              <AccordionButton>
-                <Box flex="1" textAlign="left">
-                  <Heading size="md">Governance</Heading>
-                </Box>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel pb={4}>
-                <AppLink
-                  href="https://vote.rari.capital"
-                  as={Box}
-                  h="100%"
-                  w="100%"
-                  flex="1"
-                  _hover={{ background: "grey" }}
-                  p={3}
-                  onClick={onClose}
-                >
-                  <Heading size="sm">Snapshot</Heading>
-                </AppLink>
-                <ModalDivider />
-                <AppLink
-                  href="https://forums.rari.capital"
-                  as={Box}
-                  h="100%"
-                  w="100%"
-                  flex="1"
-                  _hover={{ background: "grey" }}
-                  p={3}
-                  onClick={onClose}
-                >
-                  <Heading size="sm">Forums</Heading>
-                </AppLink>
-              </AccordionPanel>
-            </AccordionItem>
-
-            {/* Tools */}
-            <AccordionItem p={3} h="100%" w="100%" flex="1">
-              <AccordionButton>
-                <Box flex="1" textAlign="left">
-                  <Heading size="md">Tools</Heading>
-                </Box>
-                <AccordionIcon />
-              </AccordionButton>
-              <AccordionPanel pb={4}>
-                <AppLink
-                  href="/positions"
-                  as={Box}
-                  h="100%"
-                  w="100%"
-                  flex="1"
-                  _hover={{ background: "grey" }}
-                  p={3}
-                  onClick={onClose}
-                >
-                  <Heading size="sm">Positions</Heading>
-                </AppLink>
-                <ModalDivider />
-                <AppLink
-                  href="utils/interest-rates"
-                  as={Box}
-                  h="100%"
-                  w="100%"
-                  flex="1"
-                  _hover={{ background: "grey" }}
-                  p={3}
-                  onClick={onClose}
-                >
-                  <Heading size="sm">Interest Rates</Heading>
-                </AppLink>
-              </AccordionPanel>
-            </AccordionItem>
+            <MobileNavAccordionItem
+              name={t("Products")}
+              items={PRODUCTS_DROPDOWN_ITEMS}
+            />
+            <MobileNavAccordionItem
+              name={t("Governance")}
+              items={GOVERNANCE_DROPDOWN_ITEMS}
+            />
+            <MobileNavAccordionItem
+              name={t("Tools")}
+              items={UTILS_DROPDOWN_ITEMS}
+            />
           </Accordion>
-          <ModalDivider />
 
-          <HeaderSearchbar w="100%" mx="auto" />
+          <Box mt={3} p={3} width="100%">
+            <HeaderSearchbar mx="auto" width="100%" />
+          </Box>
         </Column>
       </ModalContent>
     </Modal>


### PR DESCRIPTION
Changes in this PR:

* Replace the hardcoded links in the mobile nav with the same navbar link constants used by the desktop navbar. The mobile links now match the desktop navbar except that "Governance" is kept in mobile, and any changes made to the navbar link constants will be automatically reflected on both mobile and desktop
* Update the overall design of the mobile navigation modal
   * Link group titles (e.g. "Vaults" under "Products") use the same text style as the network switcher, see #5 

Once https://github.com/Rari-Capital/rari-dApp-next/pull/9 is merged, I'll use the semibold font in the mobile nav as well.

## Old

<img width="350" alt="Screen Shot 2022-01-17 at 17 49 47" src="https://user-images.githubusercontent.com/10874225/149856823-77c170f4-5e0b-4719-b63c-e58d96a17366.png"><img width="350" alt="Screen Shot 2022-01-17 at 17 50 35" src="https://user-images.githubusercontent.com/10874225/149856906-1dc402f6-42ad-43bd-bfa6-072ef7d8365a.png">


## New

<img width="350" alt="Screen Shot 2022-01-17 at 17 45 39" src="https://user-images.githubusercontent.com/10874225/149856501-c970665f-620a-4ac9-a1db-23b23c2d1aaa.png"><img width="350" alt="Screen Shot 2022-01-17 at 17 46 10" src="https://user-images.githubusercontent.com/10874225/149856550-9b650e8e-18fa-4da3-bb84-268632bb332a.png">

