### PR TITLE
Make table design more consistent in explore and token page

### DIFF
--- a/src/components/pages/TokenDetails/FusePoolListForToken.tsx
+++ b/src/components/pages/TokenDetails/FusePoolListForToken.tsx
@@ -26,11 +26,28 @@ import { GET_UNDERLYING_ASSET_WITH_POOLS } from "gql/underlyingAssets/getUnderly
 import { ChainID } from "esm/utils/networks";
 import { useRari } from "context/RariContext";
 
-const fetchUnderlyingAssetWithPools = async (tokenAddress: string, chainId: ChainID) => {
+const thStyle = {
+  fontSize: "initial",
+  fontWeight: "normal",
+  color: "rgba(255,255,255,0.5)",
+  textTransform: "none",
+  letterSpacing: 0,
+  cursor: "pointer",
+  userSelect: "none",
+};
+
+const fetchUnderlyingAssetWithPools = async (
+  tokenAddress: string,
+  chainId: ChainID
+) => {
   const { underlyingAsset }: { underlyingAsset: GQLUnderlyingAsset } =
-    await makeGqlRequest(GET_UNDERLYING_ASSET_WITH_POOLS, {
-      tokenAddress,
-    }, chainId);
+    await makeGqlRequest(
+      GET_UNDERLYING_ASSET_WITH_POOLS,
+      {
+        tokenAddress,
+      },
+      chainId
+    );
   return underlyingAsset;
 };
 
@@ -70,8 +87,8 @@ const FusePoolListForToken = ({ token }: { token: TokenData }) => {
     const poolUnderlyingsMap: { [id: string]: string[] } = {};
     pools.forEach(
       (pool) =>
-      (poolUnderlyingsMap[pool.id] =
-        pool.underlyingAssets?.map(({ id }) => id) ?? [])
+        (poolUnderlyingsMap[pool.id] =
+          pool.underlyingAssets?.map(({ id }) => id) ?? [])
     );
     return poolUnderlyingsMap;
   }, [pools]);
@@ -87,23 +104,31 @@ const FusePoolListForToken = ({ token }: { token: TokenData }) => {
   return (
     <Box w="100%" h="100%" bg="" overflowY="scroll">
       <Table variant="unstyled">
-        <Thead position="sticky" top={0} left={0} bg="" zIndex={4}>
-          <Tr bg="black" color="#7D7D7D">
-            <Th fontSize="sm" fontWeight="normal">
-              Fuse Pool
-            </Th>
-            <Th fontSize="sm" fontWeight="normal">
-              Asset Liquidity
-            </Th>
-            <Th fontSize="sm" fontWeight="normal">
-              Lend APY
-            </Th>
-            <Th fontSize="sm" fontWeight="normal">
-              Borrow APR
-            </Th>
-            <Th fontSize="sm" fontWeight="normal" position="relative">
+        <Thead
+          position="sticky"
+          top={-1}
+          left={0}
+          bg="black"
+          zIndex={4}
+          // Simulates a border-bottom while respecting z-index
+          _after={{
+            content: `""`,
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: "1px",
+            backgroundColor: "rgba(255,255,255,0.1)",
+          }}
+        >
+          <Tr>
+            <Th style={thStyle}>Fuse Pool</Th>
+            <Th style={thStyle}>Asset Liquidity</Th>
+            <Th style={thStyle}>Lend APY</Th>
+            <Th style={thStyle}>Borrow APR</Th>
+            <Th style={thStyle} position="relative">
               <HStack alignContent="flex-end">
-                <Text>Borrow against</Text>
+                <Text>Borrow Against</Text>
                 <ViewIcon
                   _hover={{
                     cursor: "pointer",
@@ -126,7 +151,7 @@ const FusePoolListForToken = ({ token }: { token: TokenData }) => {
                 />
               )}
             </Th>
-            <Th fontSize="sm" />
+            <Th style={thStyle} />
           </Tr>
         </Thead>
         <Tbody w="100%">
@@ -227,9 +252,9 @@ const FusePoolRow = ({
       className="hover-row no-underline"
       width="100%"
       height="90px"
-      borderTop="1px solid #272727"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      borderBottom="1px solid rgba(255,255,255,0.1)"
     >
       {/* Pool */}
       <Td>

--- a/src/components/pages/TokenDetails/FusePoolListForToken.tsx
+++ b/src/components/pages/TokenDetails/FusePoolListForToken.tsx
@@ -26,14 +26,19 @@ import { GET_UNDERLYING_ASSET_WITH_POOLS } from "gql/underlyingAssets/getUnderly
 import { ChainID } from "esm/utils/networks";
 import { useRari } from "context/RariContext";
 
-const thStyle = {
-  fontSize: "initial",
-  fontWeight: "normal",
-  color: "rgba(255,255,255,0.5)",
-  textTransform: "none",
-  letterSpacing: 0,
-  cursor: "pointer",
-  userSelect: "none",
+const PoolTh: React.FC<React.ComponentProps<typeof Th>> = (props) => {
+  return (
+    <Th
+      fontSize="initial"
+      fontWeight="normal"
+      color="rgba(255,255,255,0.5)"
+      textTransform="none"
+      letterSpacing={0}
+      cursor="pointer"
+      userSelect="none"
+      {...props}
+    />
+  );
 };
 
 const fetchUnderlyingAssetWithPools = async (
@@ -122,11 +127,11 @@ const FusePoolListForToken = ({ token }: { token: TokenData }) => {
           }}
         >
           <Tr>
-            <Th style={thStyle}>Fuse Pool</Th>
-            <Th style={thStyle}>Asset Liquidity</Th>
-            <Th style={thStyle}>Lend APY</Th>
-            <Th style={thStyle}>Borrow APR</Th>
-            <Th style={thStyle} position="relative">
+            <PoolTh>Fuse Pool</PoolTh>
+            <PoolTh>Asset Liquidity</PoolTh>
+            <PoolTh>Lend APY</PoolTh>
+            <PoolTh>Borrow APR</PoolTh>
+            <PoolTh position="relative">
               <HStack alignContent="flex-end">
                 <Text>Borrow Against</Text>
                 <ViewIcon
@@ -150,8 +155,8 @@ const FusePoolListForToken = ({ token }: { token: TokenData }) => {
                   setFilteredTokens={setFilteredTokens}
                 />
               )}
-            </Th>
-            <Th style={thStyle} />
+            </PoolTh>
+            <PoolTh />
           </Tr>
         </Thead>
         <Tbody w="100%">

--- a/src/components/shared/Lists/AssetsList.tsx
+++ b/src/components/shared/Lists/AssetsList.tsx
@@ -2,20 +2,17 @@ import { Text } from "@chakra-ui/layout";
 import { Spinner } from "@chakra-ui/spinner";
 import { Avatar, Center, Stack } from "@chakra-ui/react";
 import AppLink from "components/shared/AppLink";
-import { ModalDivider } from "components/shared/Modal";
 import { Box, Table, Tbody, Td, Thead, Tr } from "@chakra-ui/react";
 
 // Hooks
-import useSWR from "swr";
 import { useTranslation } from "next-i18next";
 
 // Utils
-import { Column, Row, useIsMobile } from "lib/chakraUtils";
+import { Row, useIsMobile } from "lib/chakraUtils";
 
 // Types
 import { RariApiTokenData, TokensDataMap } from "types/tokens";
 import { SubgraphUnderlyingAsset } from "pages/api/explore";
-import { useSortableList } from "hooks/useSortableList";
 import { SortableTableHeader } from "./Common";
 import { smallUsdFormatter } from "utils/bigUtils";
 import useInfiniteScroll from "react-infinite-scroll-hook";
@@ -24,7 +21,6 @@ import { fetchTokensAPIDataAsMap } from "utils/services";
 import usePagination from "hooks/usePagination";
 import { useUnderlyingAssetsCount } from "components/pages/ExplorePage/TokenExplorer/TokenExplorer";
 import { useEffect, useMemo, useState } from "react";
-import { useTokensDataAsMap } from "hooks/useTokenData";
 import { useQuery } from "react-query";
 import { useRari } from "context/RariContext";
 
@@ -38,13 +34,13 @@ const useUnderlyingAssetsPaginated = (
   offset: number,
   limit: number,
   orderBy: string = "address",
-  orderDir: "asc" | "desc" = "asc",
+  orderDir: "asc" | "desc" = "asc"
 ) => {
   const { chainId } = useRari();
   return useQuery(
     `Underlying Assets ${orderDir} by ${orderBy} offset ${offset} limit ${limit} chainId ${chainId}`,
     async (): Promise<SubgraphUnderlyingAsset[]> => {
-      if (!chainId) return []
+      if (!chainId) return [];
       const underlyingAssets = await queryUnderlyingAssetsPaginated(
         chainId,
         offset,
@@ -71,12 +67,7 @@ export const AllAssetsList = () => {
   const { data: count } = useUnderlyingAssetsCount();
 
   // GQL Pagination logic
-  const {
-    limit,
-    offset,
-    hasMore,
-    handleLoadMore,
-  } = usePagination(count);
+  const { limit, offset, hasMore, handleLoadMore } = usePagination(count);
 
   // // Query GQL
   const { data: newAssets, isLoading } = useUnderlyingAssetsPaginated(
@@ -92,9 +83,11 @@ export const AllAssetsList = () => {
   // We use this to compare changes on `newAssetsUnderlyings` for the below useEffect
   const flag = useMemo(() => newAssetsUnderlyings[0], [newAssetsUnderlyings]);
   useEffect(() => {
-    fetchTokensAPIDataAsMap(newAssetsUnderlyings, chainId).then((newTokensData) => {
-      setTokensData(Object.assign(tokensData, newTokensData));
-    });
+    fetchTokensAPIDataAsMap(newAssetsUnderlyings, chainId).then(
+      (newTokensData) => {
+        setTokensData(Object.assign(tokensData, newTokensData));
+      }
+    );
   }, [flag, chainId]);
 
   useEffect(() => {
@@ -115,8 +108,8 @@ export const AllAssetsList = () => {
   });
 
   useEffect(() => {
-    setUnderlyingAssets([])
-  }, [chainId])
+    setUnderlyingAssets([]);
+  }, [chainId]);
 
   return (
     <Box h="400px" w="100%" overflowY="scroll">
@@ -129,7 +122,23 @@ export const AllAssetsList = () => {
       ) : (
         <>
           <Table variant="unstyled">
-            <Thead position="sticky" top={0} left={0} bg="#121212" zIndex={10}>
+            <Thead
+              position="sticky"
+              top={0}
+              left={0}
+              zIndex={10}
+              background="black"
+              // Simulates a border-bottom while respecting z-index
+              _after={{
+                content: `""`,
+                position: "absolute",
+                bottom: 0,
+                left: 0,
+                right: 0,
+                height: "1px",
+                backgroundColor: "rgba(255,255,255,0.1)",
+              }}
+            >
               <Tr>
                 <SortableTableHeader
                   text="Asset"
@@ -167,14 +176,11 @@ export const AllAssetsList = () => {
             <Tbody ref={rootRef}>
               {underlyingAssets.map((underlyingAsset) => {
                 return (
-                  <>
-                    <AssetRow
-                      asset={underlyingAsset}
-                      tokenData={tokensData[underlyingAsset.id]}
-                      key={underlyingAsset.symbol}
-                    />
-                    <ModalDivider />
-                  </>
+                  <AssetRow
+                    asset={underlyingAsset}
+                    tokenData={tokensData[underlyingAsset.id]}
+                    key={underlyingAsset.symbol}
+                  />
                 );
               })}
               {hasMore && (
@@ -211,6 +217,7 @@ export const AssetRow = ({
       as={Tr}
       className="hover-row no-underline"
       width="100%"
+      borderBottom="1px solid rgba(255,255,255,0.1)"
       {...rowProps}
     >
       {/* Pool */}
@@ -240,7 +247,8 @@ export const AssetRow = ({
               </Text>
               <Text fontWeight="" fontSize="sm">
                 {asset.totalSupply &&
-                  `${(asset.totalSupply / 10 ** asset.decimals).toFixed(2)} ${asset.symbol
+                  `${(asset.totalSupply / 10 ** asset.decimals).toFixed(2)} ${
+                    asset.symbol
                   }`}
               </Text>
             </Stack>
@@ -254,7 +262,8 @@ export const AssetRow = ({
               </Text>
               <Text fontWeight="" fontSize="sm">
                 {asset.totalBorrow &&
-                  `${(asset.totalBorrow / 10 ** asset.decimals).toFixed(2)} ${asset.symbol
+                  `${(asset.totalBorrow / 10 ** asset.decimals).toFixed(2)} ${
+                    asset.symbol
                   }`}
               </Text>
             </Stack>

--- a/src/components/shared/Lists/Common.tsx
+++ b/src/components/shared/Lists/Common.tsx
@@ -14,12 +14,20 @@ export const SortableTableHeader = ({
 }) => {
   return (
     <Th
-      fontSize="sm"
-      _hover={{ cursor: "pointer", textDecoration: "underline" }}
+      fontSize="initial"
+      fontWeight="normal"
+      color="rgba(255,255,255,0.5)"
+      textTransform="none"
+      letterSpacing={0}
+      borderBottomWidth={1}
+      borderBottomStyle="solid"
+      borderBottomColor="rgba(255,255,255,0.1)"
+      cursor="pointer"
+      userSelect="none"
       onClick={handleSortClick}
     >
       <Stack direction="row">
-        <Text fontWeight="bold">{text}</Text>
+        <Text>{text}</Text>
         <Icon as={getSortIcon(isActive, sortDir)} />
       </Stack>
     </Th>


### PR DESCRIPTION
This PR makes the table look and feel more consistent between the Explore and individual token pages, based on Aaron's earlier table designs for the portfolio page.

## Aaron's Figma Design for Portfolio Page

<img width="800" alt="Screen Shot 2022-01-20 at 22 33 29" src="https://user-images.githubusercontent.com/10874225/150478204-e2278e46-2b3b-483f-81dd-31787c77f9b2.png">

## Explore Page (old/new)

<img width="800" alt="Screen Shot 2022-01-20 at 22 34 42" src="https://user-images.githubusercontent.com/10874225/150478365-ec56a572-2ff7-493d-a092-bc3c1925ec2d.png">
<img width="800" alt="Screen Shot 2022-01-20 at 22 37 00" src="https://user-images.githubusercontent.com/10874225/150478630-37172abc-1681-4269-86f5-c64963b53a4c.png">


## Token Page (old/new)
<img width="800" alt="Screen Shot 2022-01-20 at 22 34 17" src="https://user-images.githubusercontent.com/10874225/150478302-18f20070-8251-45a9-a723-f1fd8f465373.png">
<img width="800" alt="Screen Shot 2022-01-20 at 22 37 29" src="https://user-images.githubusercontent.com/10874225/150478699-79fa590a-c427-496f-9f13-bc9fce3ed6f8.png">


