### PR TITLE
Rewrite instances of foreach to use functional array methods

### DIFF
--- a/src/components/pages/ExplorePage/ExplorePage.tsx
+++ b/src/components/pages/ExplorePage/ExplorePage.tsx
@@ -172,10 +172,12 @@ const recommendedPoolsFetcher = async (
   }
 
   // reduce poolsMap to only pools which were recommended
-  const recommendedPoolDataMap: RecommendedPoolDataMap = {};
-  Object.values(map).forEach(({ poolId }) => {
-    recommendedPoolDataMap[poolId] = poolsMap[poolId];
-  });
+  const recommendedPoolDataMap = Object.values(
+    map
+  ).reduce<RecommendedPoolDataMap>((acc, { poolId }) => {
+    acc[poolId] = poolsMap[poolId];
+    return acc;
+  }, {});
   poolsMap = {};
 
   return {

--- a/src/components/pages/Home/HomeFuseCard.tsx
+++ b/src/components/pages/Home/HomeFuseCard.tsx
@@ -29,7 +29,9 @@ const HomeFuseCard = ({
 
   const { title, subtitle }: HomepageFusePool = useMemo(() => {
     if (!pool) return { title: null, subtitle: null, id: -1 };
-    return HOMEPAGE_FUSE_POOLS[chainId ?? 1].find((p) => p.id == parseInt(pool.index))!;
+    return HOMEPAGE_FUSE_POOLS[chainId ?? 1].find(
+      (p) => p.id == parseInt(pool.index)
+    )!;
   }, [pool]);
 
   const isMobile = useIsMobile();
@@ -39,18 +41,18 @@ const HomeFuseCard = ({
 
     const NUM = 3;
 
-    const symbols: string[] = [];
-
-    pool.assets.forEach((a, i) => {
-      const { symbol } = a.underlying;
-      if (i < NUM && symbol) symbols.push(symbol!);
-    });
+    const symbols = pool.assets
+      .map(({ underlying }) => underlying.symbol)
+      .slice(0, NUM);
 
     let caption;
-    if (pool.assets.length <= 3) {
+    if (pool.assets.length <= NUM) {
       caption = symbols.join(", ");
     } else {
-      caption = `${symbols.join(", ")}, and ${pool.assets.length - NUM} others`;
+      const remaining = pool.assets.length - NUM;
+      caption = `${symbols.join(", ")}, and ${remaining} other${
+        remaining > 1 ? "s" : ""
+      }`;
     }
 
     return caption;

--- a/src/components/pages/TokenDetails/FusePoolListForToken.tsx
+++ b/src/components/pages/TokenDetails/FusePoolListForToken.tsx
@@ -73,10 +73,11 @@ const FusePoolListForToken = ({ token }: { token: TokenData }) => {
   const pools = useSubgraphPoolsForToken(token?.address);
 
   const underlyingAssets = useMemo(() => {
-    const tokens = new Set<string>();
-    pools.forEach(({ underlyingAssets }) => {
-      underlyingAssets!.forEach(({ id }) => tokens.add(id));
-    });
+    const tokenIds = pools
+      .flatMap(({ underlyingAssets }) => underlyingAssets?.map(({ id }) => id))
+      .filter((tokenId): tokenId is string => typeof tokenId !== "undefined");
+    // Set constructor will automatically remove duplicates
+    const tokens = new Set<string>(tokenIds);
     return [...tokens];
   }, [pools]);
 


### PR DESCRIPTION
This PR fixes a small pluralization bug in `HomeFuseCard` (the card should read "1 other" rather than "1 others" in pool asset listing when there is 1 hidden asset) and rewrites a few uses of `Array#forEach` to instead use more specialized functional array methods like `map`, `reduce`, and `filter` to reduce the amount of mutability/changing state and hopefully increase clarity.

I ran the web app and spot checked the components on the pages they were used on to make sure there were no regressions.

## On Performance

All of the functional array methods (`forEach` included) have similar performance characteristics so these changes shouldn't have an effect on performance, but another direction we can go here is to use pure `for` loops which according to [some benchmarks](https://leanylabs.com/blog/js-forEach-map-reduce-vs-for-for_of/) are 2x - 3x faster. However, I think that the clarity and expressiveness of the functional array methods outweighs the costs (it's just a constant factor anyways and there are probably places we can move the needle on performance much more).

Let me know your thoughts on all this/whether we should prefer the more specific functional Array methods over `forEach` going forward or not.

