### PR TITLE
Fix mobile header bug

### DIFF
--- a/src/components/shared/Header2/HeaderSearchbar.tsx
+++ b/src/components/shared/Header2/HeaderSearchbar.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import Searchbar from "../Searchbar";
 
 type HeaderSearchbarProps = {
-  width: StyleProps["width"];
+  width?: StyleProps["width"];
 };
 
 const HeaderSearchbar: React.FC<HeaderSearchbarProps> = ({

--- a/src/components/shared/Header2/HeaderSearchbar.tsx
+++ b/src/components/shared/Header2/HeaderSearchbar.tsx
@@ -1,8 +1,15 @@
+import { StyleProps } from "@chakra-ui/react";
 import React from "react";
 import Searchbar from "../Searchbar";
 
-const HeaderSearchbar: React.FC = () => {
-  return <Searchbar width="375px" height="33px" smaller />;
+type HeaderSearchbarProps = {
+  width: StyleProps["width"];
+};
+
+const HeaderSearchbar: React.FC<HeaderSearchbarProps> = ({
+  width = "375px",
+}) => {
+  return <Searchbar width={width} height="33px" smaller />;
 };
 
 export default HeaderSearchbar;

--- a/src/components/shared/Header2/HeaderSearchbar.tsx
+++ b/src/components/shared/Header2/HeaderSearchbar.tsx
@@ -1,13 +1,8 @@
-import { Box } from "@chakra-ui/react";
 import React from "react";
 import Searchbar from "../Searchbar";
 
-const HeaderSearchbar: React.FC<React.ComponentProps<typeof Box>> = (props) => {
-  return (
-    <Box w={800} mx={5} my="auto " alignSelf="flex-start" {...props}>
-      <Searchbar height="33px" smaller />
-    </Box>
-  );
+const HeaderSearchbar: React.FC = () => {
+  return <Searchbar width="375px" height="33px" smaller />;
 };
 
 export default HeaderSearchbar;

--- a/src/components/shared/Header2/MobileNavModal.tsx
+++ b/src/components/shared/Header2/MobileNavModal.tsx
@@ -129,7 +129,7 @@ export const MobileNavModal = ({
           </Accordion>
 
           <Box mt={3} p={3} width="100%">
-            <HeaderSearchbar mx="auto" width="100%" />
+            <HeaderSearchbar width="100%" />
           </Box>
         </Column>
       </ModalContent>

--- a/src/components/shared/Header2/NewHeader.tsx
+++ b/src/components/shared/Header2/NewHeader.tsx
@@ -1,5 +1,5 @@
 import { PixelSize, Row } from "lib/chakraUtils";
-import { Flex, Icon, useDisclosure } from "@chakra-ui/react";
+import { Box, Flex, Icon, Spacer, useDisclosure } from "@chakra-ui/react";
 
 //  Components
 import DashboardBox, { DASHBOARD_BOX_SPACING } from "../DashboardBox";
@@ -89,8 +89,10 @@ export const NewHeader = () => {
             /> */}
           </Row>
         )}
-
-        {!isMobile && <HeaderSearchbar />}
+        <Box alignSelf="flex-start" mr={5}>
+          {!isMobile && <HeaderSearchbar />}
+        </Box>
+        {!!isMobile && <Spacer />}
         <Flex>
           <AccountButton />
           {isMobile && (


### PR DESCRIPTION
I'm not 100% sure what the root cause of this issue was, but it seems like it had something to do with the `useIsSmallScreen` hook not updating sometimes on load? (because I could only reproduce the issue when I hard-refreshed the page on the Chrome devtools mobile device simulator)

When I resized the page from full-width to mobile-width, I saw the screenshot I posted in https://github.com/Rari-Capital/rari-dApp-next/pull/8.

In any case, the correct alignment now works on both initial load and resizing.

# Old / New

<img width="389" src="https://user-images.githubusercontent.com/10874225/151847269-3142f161-d154-4d52-a3ff-b5b946f9527c.png" /> <img width="389" alt="Screen Shot 2022-01-31 at 09 56 23" src="https://user-images.githubusercontent.com/10874225/151847195-1afe3526-3e02-4184-822f-500c86f7608c.png">
