### PR TITLE
Use standalone rari-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "node-fetch": "^2.6.1",
         "node-vibrant": "^3.1.6",
         "polished": "^4.1.3",
-        "rari-components": "git+https://github.com/Rari-Capital/rari-components#428603bcc0f0c7f4414e06d5b72353e91a343dd0",
+        "rari-components": "git+https://github.com/Rari-Capital/rari-components#9541f72a093da5969155d53324d281a90f7c6b1e",
         "rari-tokens-generator": "^2.0.0",
         "react": "^17.0.2",
         "react-apexcharts": "1.3.7",
@@ -15788,11 +15788,11 @@
     },
     "node_modules/rari-components": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/Rari-Capital/rari-components.git#428603bcc0f0c7f4414e06d5b72353e91a343dd0",
-      "integrity": "sha512-lwRIRDGp0VzI0KGqSnDqGOCMmvYuvQqJfFkNOtGoZS69E10cA4ThrfuzqXSHpAgBp/tiRwI/KX+xV+g4BvlLBw==",
+      "resolved": "git+ssh://git@github.com/Rari-Capital/rari-components.git#9541f72a093da5969155d53324d281a90f7c6b1e",
+      "integrity": "sha512-4bPXZTlG+RbAyrhoZzVSaUNIibshxfv0Sj8ta5Ni1xraUKrTDLCJ+FGQ0q6M34okz4bHNOz8yaT6PHdO+FvU4Q==",
       "peerDependencies": {
         "@chakra-ui/icons": "1.x",
-        "@chakra-ui/react": "1.x",
+        "@chakra-ui/react": "^1.8",
         "@emotion/react": "^11.0.0",
         "@emotion/styled": "^11.0.0",
         "ethers": "5.x",
@@ -32578,9 +32578,9 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "rari-components": {
-      "version": "git+ssh://git@github.com/Rari-Capital/rari-components.git#428603bcc0f0c7f4414e06d5b72353e91a343dd0",
-      "integrity": "sha512-lwRIRDGp0VzI0KGqSnDqGOCMmvYuvQqJfFkNOtGoZS69E10cA4ThrfuzqXSHpAgBp/tiRwI/KX+xV+g4BvlLBw==",
-      "from": "rari-components@git+https://github.com/Rari-Capital/rari-components#428603bcc0f0c7f4414e06d5b72353e91a343dd0",
+      "version": "git+ssh://git@github.com/Rari-Capital/rari-components.git#9541f72a093da5969155d53324d281a90f7c6b1e",
+      "integrity": "sha512-4bPXZTlG+RbAyrhoZzVSaUNIibshxfv0Sj8ta5Ni1xraUKrTDLCJ+FGQ0q6M34okz4bHNOz8yaT6PHdO+FvU4Q==",
+      "from": "rari-components@git+https://github.com/Rari-Capital/rari-components#9541f72a093da5969155d53324d281a90f7c6b1e",
       "requires": {}
     },
     "rari-tokens-generator": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node-fetch": "^2.6.1",
     "node-vibrant": "^3.1.6",
     "polished": "^4.1.3",
-    "rari-components": "git+https://github.com/Rari-Capital/rari-components#428603bcc0f0c7f4414e06d5b72353e91a343dd0",
+    "rari-components": "git+https://github.com/Rari-Capital/rari-components#9541f72a093da5969155d53324d281a90f7c6b1e",
     "rari-tokens-generator": "^2.0.0",
     "react": "^17.0.2",
     "react-apexcharts": "1.3.7",

--- a/src/components/pages/Home/Home.tsx
+++ b/src/components/pages/Home/Home.tsx
@@ -13,7 +13,7 @@ import { useIsSmallScreen } from "hooks/useIsSmallScreen";
 import Marquee from "react-fast-marquee";
 import HomeFuseCard from "./HomeFuseCard";
 
-import { Card } from "rari-components"
+import { Card } from "rari-components/standalone"
 
 import { motion } from "framer-motion";
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,10 +4,9 @@ import dynamic from "next/dynamic";
 import { appWithTranslation } from "next-i18next";
 
 // Providers
-import { ChakraProvider } from "@chakra-ui/react";
+import { ChakraProvider, theme } from "@chakra-ui/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
-import theme from "rari-components/theme";
 
 // Providers
 import { RariProvider } from "context/RariContext";
@@ -42,8 +41,12 @@ const AuthMiddleware = dynamic(() => import("components/Auth"), {
 
 const customTheme = {
   ...theme,
+  fonts: {
+    ...theme.fonts,
+    body: `'Avenir Next', ${theme.fonts.body}`,
+    heading: `'Avenir Next', ${theme.fonts.heading}`,
+  },
   colors: {
-    ...theme.colors,
     nav: {
       50: "#F0FFF4",
       100: "#41C143",


### PR DESCRIPTION
See https://github.com/Rari-Capital/rari-components/commit/9541f72a093da5969155d53324d281a90f7c6b1e for fix implementation on the rari-components side

Temporarily resolves the issues caused by conflicts between the main dapp's theme and the theme provided by rari-components. We should start using more component library components if we can — the fix wraps each component in its own `<ChakraProvider/>` to isolate the theme which probably won't scale.

<img width="644" alt="Screen Shot 2022-03-17 at 18 27 51" src="https://user-images.githubusercontent.com/10874225/158920000-367cfa44-0393-4dc9-8f51-a1225a049559.png">
 