### PR TITLE
Update: Prettier setting file "jsxBracketSameLine" was deprecated

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,5 @@
   "printWidth": 80,
   "tabWidth": 2,
   "singleQuote": false,
-  "jsxBracketSameLine": false
+  "bracketSameLine":false
 }


### PR DESCRIPTION
Prettier Setting was deprecated.

Replace `JsxBrackeSameLine` to `bracketSameLine`. 

Here is the document
![image](https://user-images.githubusercontent.com/34936929/162434792-690a4206-5742-48ba-9f0b-e99236511381.png)
