### PR TITLE
Use newest version of rari-components StatisticsTable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "node-fetch": "^2.6.1",
         "node-vibrant": "^3.1.6",
         "polished": "^4.1.3",
-        "rari-components": "github:Rari-Capital/rari-components#368c51c1b75aafe3830ab2ed100713b1b11e770d",
+        "rari-components": "github:Rari-Capital/rari-components#88056a1b1a74b8bc18ebc6d3efb6674e3a973d76",
         "rari-tokens-generator": "^2.0.0",
         "react": "^17.0.2",
         "react-apexcharts": "1.3.7",
@@ -15788,8 +15788,8 @@
     },
     "node_modules/rari-components": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/Rari-Capital/rari-components.git#368c51c1b75aafe3830ab2ed100713b1b11e770d",
-      "integrity": "sha512-qm3ZzgwsgqrSYT5QyHXKTP7wX1deUvW391VCkquUAWXpdsohkd2hyaC9QWLowYEpvHPqelmhk0wzP5gsILAytw==",
+      "resolved": "git+ssh://git@github.com/Rari-Capital/rari-components.git#88056a1b1a74b8bc18ebc6d3efb6674e3a973d76",
+      "integrity": "sha512-hlYetNt83gYi4OYPcmJuVkgKmcduRXrAyuZCD9M/VI2tyAMzj+3MdILO2ecAEvPlzGoMEMj3aChhamUMGRA5qg==",
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -32595,9 +32595,9 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "rari-components": {
-      "version": "git+ssh://git@github.com/Rari-Capital/rari-components.git#368c51c1b75aafe3830ab2ed100713b1b11e770d",
-      "integrity": "sha512-qm3ZzgwsgqrSYT5QyHXKTP7wX1deUvW391VCkquUAWXpdsohkd2hyaC9QWLowYEpvHPqelmhk0wzP5gsILAytw==",
-      "from": "rari-components@git+https://github.com/Rari-Capital/rari-components#368c51c1b75aafe3830ab2ed100713b1b11e770d",
+      "version": "git+ssh://git@github.com/Rari-Capital/rari-components.git#88056a1b1a74b8bc18ebc6d3efb6674e3a973d76",
+      "integrity": "sha512-hlYetNt83gYi4OYPcmJuVkgKmcduRXrAyuZCD9M/VI2tyAMzj+3MdILO2ecAEvPlzGoMEMj3aChhamUMGRA5qg==",
+      "from": "rari-components@git+https://github.com/Rari-Capital/rari-components#88056a1b1a74b8bc18ebc6d3efb6674e3a973d76",
       "requires": {
         "lodash": "^4.17.21"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node-fetch": "^2.6.1",
     "node-vibrant": "^3.1.6",
     "polished": "^4.1.3",
-    "rari-components": "github:Rari-Capital/rari-components#368c51c1b75aafe3830ab2ed100713b1b11e770d",
+    "rari-components": "github:Rari-Capital/rari-components#88056a1b1a74b8bc18ebc6d3efb6674e3a973d76",
     "rari-tokens-generator": "^2.0.0",
     "react": "^17.0.2",
     "react-apexcharts": "1.3.7",

--- a/src/components/pages/Turbo/TurboIndexPage/CreateSafeModal/modalSteps.tsx
+++ b/src/components/pages/Turbo/TurboIndexPage/CreateSafeModal/modalSteps.tsx
@@ -1,12 +1,11 @@
 import { BigNumber, constants, utils } from "ethers";
 import { commify, formatEther } from "ethers/lib/utils";
-import StatisticTable from "lib/components/StatisticsTable";
-import { createSafe } from "lib/turbo/transactions/safe";
 import {
   Heading,
   HoverableCard,
   ModalProps,
-  StatisticTable as RariStats,
+  StatisticsTable,
+  StatisticsTableProps,
   Text,
   TokenAmountInput,
   TokenIcon,
@@ -158,69 +157,87 @@ const MODAL_STEP_3: ModalStep = {
     collateralBalance,
     setDepositAmount,
     safeSimulation,
-  }) => (
-    <Stack>
-      <Box>
-        <VStack w="100%" mb={3} align="flex-end">
-          <TokenAmountInput
-            tokenAddress={underlyingTokenAddress}
-            value={depositAmount}
-            onChange={setDepositAmount}
-            onClickMax={onClickMax}
-          />
-          <Text variant="secondary" mt="4" _hover={{ cursor: "default" }}>
-            Balance: {commify(collateralBalance)}{" "}
-            <TokenSymbol tokenAddress={underlyingTokenAddress} />
-          </Text>
-        </VStack>
-        <StatisticTable
-          statistics={[
-            {
-              title: "Collateral",
-              primaryValue: `0`,
-              secondaryValue:
-                !depositAmount || depositAmount === "0"
-                  ? undefined
-                  : `${commify(depositAmount ?? 0)}`,
-              titleTooltip: "How much collateral you have deposited.",
-            },
-            {
-              title: "Collateral value",
-              primaryValue: "0",
-              secondaryValue:
-                !depositAmount || depositAmount === "0" || !safeSimulation
-                  ? undefined
-                  : "$" +
-                    commify(
-                      parseFloat(
-                        formatEther(
-                          safeSimulation?.collateralUSD ?? constants.Zero
-                        )
-                      ).toFixed(2)
-                    ),
-              titleTooltip:
-                "The total collateral value denominated in dollars.",
-            },
-            {
-              title: "Max boost",
-              primaryValue: "0",
-              secondaryValue:
-                !depositAmount || depositAmount === "0" || !safeSimulation
-                  ? undefined
-                  : "$" +
-                    commify(
-                      parseFloat(
-                        formatEther(safeSimulation?.maxBoost ?? constants.Zero)
-                      ).toFixed(2)
-                    ),
-              titleTooltip: "The total boostable amount.",
-            },
-          ]}
-          mt={4}
-        />
-      </Box>
-    </Stack>
-  ),
+  }) => {
+    const collateralStatistic =
+      !depositAmount || depositAmount === "0" ? (
+        "0"
+      ) : (
+        <Text fontWeight={600}>
+          0 →{" "}
+          <Box as="span" color="neutral">
+            {commify(depositAmount ?? 0)}
+          </Box>
+        </Text>
+      );
+
+    const collateralValueStatistic =
+      !depositAmount || depositAmount === "0" || !safeSimulation ? (
+        "0"
+      ) : (
+        <Text fontWeight={600}>
+          0 →{" "}
+          <Box as="span" color="neutral">
+            $
+            {commify(
+              parseFloat(
+                formatEther(safeSimulation?.collateralUSD ?? constants.Zero)
+              ).toFixed(2)
+            )}
+          </Box>
+        </Text>
+      );
+
+    const maxBoostStatistic =
+      !depositAmount || depositAmount === "0" || !safeSimulation ? (
+        "0"
+      ) : (
+        <Text fontWeight={600}>
+          0 →{" "}
+          <Box as="span" color="neutral">
+            $
+            {commify(
+              parseFloat(
+                formatEther(safeSimulation?.maxBoost ?? constants.Zero)
+              ).toFixed(2)
+            )}
+          </Box>
+        </Text>
+      );
+
+    const statistics: StatisticsTableProps["statistics"] = [
+      [
+        "Collateral",
+        collateralStatistic,
+        "How much collateral you have deposited.",
+      ],
+      [
+        "Collateral value",
+        collateralValueStatistic,
+        "The total collateral value denominated in dollars.",
+      ],
+      ["Max boost", maxBoostStatistic, "The total boostable amount."],
+    ];
+
+    return (
+      <Stack>
+        <Box>
+          <VStack w="100%" mb={3} align="flex-end">
+            <TokenAmountInput
+              tokenAddress={underlyingTokenAddress}
+              value={depositAmount}
+              onChange={setDepositAmount}
+              onClickMax={onClickMax}
+            />
+            <Text variant="secondary" mt="4" _hover={{ cursor: "default" }}>
+              Balance: {commify(collateralBalance)}{" "}
+              <TokenSymbol tokenAddress={underlyingTokenAddress} />
+            </Text>
+          </VStack>
+          <StatisticsTable statistics={statistics} />
+        </Box>
+      </Stack>
+    );
+  },
   buttons: ({
     incrementStepIndex,
     setDepositAmount,
@@ -261,7 +278,7 @@ const MODAL_STEP_4: ModalStep = {
         </Heading>
       </Box>
       {!depositAmount || depositAmount === "0" ? null : (
-        <RariStats
+        <StatisticsTable
           mt={8}
           statistics={[
             ["Collateral deposited", `${utils.commify(depositAmount ?? "0")}`],

--- a/src/components/pages/Turbo/TurboSafePage/modals/ClaimInterestModal/modalSteps.tsx
+++ b/src/components/pages/Turbo/TurboSafePage/modals/ClaimInterestModal/modalSteps.tsx
@@ -1,4 +1,4 @@
-import { BigNumber, constants } from "ethers";
+import { BigNumber } from "ethers";
 import { commify, formatEther } from "ethers/lib/utils";
 import { StrategyInfosMap } from "hooks/turbo/useStrategyInfo";
 import {
@@ -7,15 +7,12 @@ import {
 } from "lib/turbo/fetchers/safes/getUSDPricedSafeInfo";
 import { FEI } from "lib/turbo/utils/constants";
 import {
-  Divider,
   Heading,
   ModalProps,
-  StatisticTable,
+  StatisticsTable,
   Text,
   TokenIcon,
-  TokenSymbol,
 } from "rari-components";
-import { abbreviateAmount, smallUsdFormatter } from "utils/bigUtils";
 import { CheckCircleIcon } from "@chakra-ui/icons";
 import { Box, HStack, Stack, VStack } from "@chakra-ui/react";
 
@@ -55,8 +52,7 @@ const MODAL_STEP_1: ModalStep = {
           {commify(parseFloat(formatEther(totalClaimable)).toFixed(2))} FEI
         </Heading>
       </HStack>
-
-      <StatisticTable
+      <StatisticsTable
         w="100%"
         statistics={[
           [


### PR DESCRIPTION
Update the dapp to reflect latest updates to rari-components:

* StatisticTable was renamed to StatisticsTable to reflect that it contains multiple statistics
* StatisticsTable now supports arbitrary ReactNode statistics (so statistics can have colors) and tooltips (also, tooltips were moved to correspond to position in Figma designs)

# Before/After

<div>
<img width="300" alt="Screen Shot 2022-04-13 at 20 32 04" src="https://user-images.githubusercontent.com/10874225/163308383-2bc85264-2989-4366-b1c4-f31a8c6df0ea.png">
<img width="310" alt="Screen Shot 2022-04-13 at 20 31 31" src="https://user-images.githubusercontent.com/10874225/163308324-d69dff36-96d3-4942-a827-044725344f51.png">
</div>

