### PR TITLE
Update Boost Modal StatisticsTable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "node-fetch": "^2.6.1",
         "node-vibrant": "^3.1.6",
         "polished": "^4.1.3",
-        "rari-components": "github:Rari-Capital/rari-components#88056a1b1a74b8bc18ebc6d3efb6674e3a973d76",
+        "rari-components": "github:Rari-Capital/rari-components#a277878842cb5c6f74193d972002dc71aa185319",
         "rari-tokens-generator": "^2.0.0",
         "react": "^17.0.2",
         "react-apexcharts": "1.3.7",
@@ -15788,8 +15788,8 @@
     },
     "node_modules/rari-components": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/Rari-Capital/rari-components.git#88056a1b1a74b8bc18ebc6d3efb6674e3a973d76",
-      "integrity": "sha512-hlYetNt83gYi4OYPcmJuVkgKmcduRXrAyuZCD9M/VI2tyAMzj+3MdILO2ecAEvPlzGoMEMj3aChhamUMGRA5qg==",
+      "resolved": "git+ssh://git@github.com/Rari-Capital/rari-components.git#a277878842cb5c6f74193d972002dc71aa185319",
+      "integrity": "sha512-a7tk+4VH1pklW+gA59xFGxOTpw6dVoAxbI5JuKBpGLtPvHS5lTNwnduTB7zJcLK9bjENuOiCMkgRj/mPlSsnGA==",
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -32595,9 +32595,9 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "rari-components": {
-      "version": "git+ssh://git@github.com/Rari-Capital/rari-components.git#88056a1b1a74b8bc18ebc6d3efb6674e3a973d76",
-      "integrity": "sha512-hlYetNt83gYi4OYPcmJuVkgKmcduRXrAyuZCD9M/VI2tyAMzj+3MdILO2ecAEvPlzGoMEMj3aChhamUMGRA5qg==",
-      "from": "rari-components@git+https://github.com/Rari-Capital/rari-components#88056a1b1a74b8bc18ebc6d3efb6674e3a973d76",
+      "version": "git+ssh://git@github.com/Rari-Capital/rari-components.git#a277878842cb5c6f74193d972002dc71aa185319",
+      "integrity": "sha512-a7tk+4VH1pklW+gA59xFGxOTpw6dVoAxbI5JuKBpGLtPvHS5lTNwnduTB7zJcLK9bjENuOiCMkgRj/mPlSsnGA==",
+      "from": "rari-components@git+https://github.com/Rari-Capital/rari-components#a277878842cb5c6f74193d972002dc71aa185319",
       "requires": {
         "lodash": "^4.17.21"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node-fetch": "^2.6.1",
     "node-vibrant": "^3.1.6",
     "polished": "^4.1.3",
-    "rari-components": "github:Rari-Capital/rari-components#88056a1b1a74b8bc18ebc6d3efb6674e3a973d76",
+    "rari-components": "github:Rari-Capital/rari-components#a277878842cb5c6f74193d972002dc71aa185319",
     "rari-tokens-generator": "^2.0.0",
     "react": "^17.0.2",
     "react-apexcharts": "1.3.7",


### PR DESCRIPTION
Update the StatisticsTable in the Boost Modal to more closely match the Figma design

# Before/After
<div>
<img width="340" alt="Screen Shot 2022-04-13 at 21 11 51" src="https://user-images.githubusercontent.com/10874225/163312232-626f3103-471a-4529-958b-ac681e3340f7.png">

<img width="320" alt="Screen Shot 2022-04-13 at 21 11 04" src="https://user-images.githubusercontent.com/10874225/163312153-fe52ba92-cbe1-45ce-b471-b512f4421bdd.png">


</div>